### PR TITLE
Upgraded Spring Boot to version 1.4.0-RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring.boot-version>1.3.5.RELEASE</spring.boot-version>
+        <spring.boot-version>1.4.0.RELEASE</spring.boot-version>
         <camel.version>2.17.1</camel.version>
         <hawtio.version>1.4.65</hawtio.version>
     </properties>
@@ -62,7 +62,7 @@
         <!-- Logging -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j</artifactId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>
             <groupId>io.hawt</groupId>


### PR DESCRIPTION
Using spring-boot-starter-log4j2 now since the old one is no longer supported